### PR TITLE
Update copylinkaddress.js left element move and absolute positioning to display: 'run-in'

### DIFF
--- a/copylinkaddress.js
+++ b/copylinkaddress.js
@@ -19,7 +19,7 @@ When you move away from the link, the caret position is restored.
 var linkAddress = $('<span id="copylAddress" style="display: inline-block;" />');
 $('body').append(linkAddress);
 // This is a DOM element that has to be selectable but not visible to anybody
-linkAddress.css({position: 'absolute', left:'-9999em'});
+linkAddress.css({position: 'absolute', display:'none'});
 
 var previousCaretPosition = -1;
 

--- a/copylinkaddress.js
+++ b/copylinkaddress.js
@@ -19,7 +19,7 @@ When you move away from the link, the caret position is restored.
 var linkAddress = $('<span id="copylAddress" style="display: inline-block;" />');
 $('body').append(linkAddress);
 // This is a DOM element that has to be selectable but not visible to anybody
-linkAddress.css({position: 'absolute', display:'none'});
+linkAddress.css({display:'run-in'});
 
 var previousCaretPosition = -1;
 


### PR DESCRIPTION
Instead of having the span element be created off of the screen which can create page jumping issues, just create it in place without it being seen so the flow of the page isn't modified.